### PR TITLE
Add Supabase RLS policies

### DIFF
--- a/supabase/README.md
+++ b/supabase/README.md
@@ -5,6 +5,7 @@ This folder contains the database files for the NativasApp MVP.
 ## Files
 
 - `schema.sql`: creates the initial tables, indexes and update triggers.
+- `rls-policies.sql`: enables Row Level Security and creates access policies.
 
 ## Initial tables
 
@@ -41,10 +42,34 @@ Main use cases:
 
 1. Open your Supabase project.
 2. Go to SQL Editor.
-3. Copy the content from `schema.sql`.
-4. Run the SQL.
-5. Continue with RLS policies before connecting production data.
+3. Run `schema.sql` first.
+4. Run `rls-policies.sql` second.
+5. Create at least one authenticated admin user.
+6. Add that user to `admin_profiles` with the `owner` role.
+7. Test permissions before using production data.
 
-## Next step
+## Public app notes
 
-Add Row Level Security policies in a separate SQL file before exposing admin features.
+- The frontend should use the public Supabase key from `.env`.
+- Public visitors can submit applications.
+- Public visitors cannot read applications.
+- Public visitors can only read published news.
+- Admin actions require an authenticated admin profile.
+
+## Project admin example
+
+Use `admin@nois.dev` for admin examples and local setup documentation.
+
+## Recommended first owner insert
+
+After creating your first Supabase Auth user, add it as owner from the SQL Editor:
+
+```sql
+insert into public.admin_profiles (id, email, display_name, role)
+values (
+  'ADMIN_USER_ID',
+  'admin@nois.dev',
+  'Admin',
+  'owner'
+);
+```

--- a/supabase/rls-policies.sql
+++ b/supabase/rls-policies.sql
@@ -1,0 +1,125 @@
+-- NativasApp Supabase RLS policies
+-- Run this after `schema.sql`.
+
+alter table public.applications enable row level security;
+alter table public.news enable row level security;
+alter table public.admin_profiles enable row level security;
+
+create or replace function public.is_admin()
+returns boolean as $$
+begin
+  return exists (
+    select 1
+    from public.admin_profiles
+    where id = auth.uid()
+      and role in ('owner', 'admin')
+  );
+end;
+$$ language plpgsql security definer set search_path = public;
+
+-- Applications
+-- Public visitors can submit an application, but cannot read applications.
+create policy "Public can submit applications"
+on public.applications
+for insert
+to anon, authenticated
+with check (
+  full_name is not null
+  and email is not null
+  and phone is not null
+  and birth_date is not null
+  and why_join is not null
+  and accepted_privacy = true
+  and status = 'new'
+  and internal_notes is null
+);
+
+create policy "Admins can read applications"
+on public.applications
+for select
+to authenticated
+using (public.is_admin());
+
+create policy "Admins can update applications"
+on public.applications
+for update
+to authenticated
+using (public.is_admin())
+with check (public.is_admin());
+
+-- News
+-- Public visitors can only read published news.
+create policy "Public can read published news"
+on public.news
+for select
+to anon, authenticated
+using (status = 'published');
+
+create policy "Admins can read all news"
+on public.news
+for select
+to authenticated
+using (public.is_admin());
+
+create policy "Admins can create news"
+on public.news
+for insert
+to authenticated
+with check (public.is_admin());
+
+create policy "Admins can update news"
+on public.news
+for update
+to authenticated
+using (public.is_admin())
+with check (public.is_admin());
+
+create policy "Admins can archive news"
+on public.news
+for delete
+to authenticated
+using (public.is_admin());
+
+-- Admin profiles
+-- Admin users can read their own profile.
+create policy "Admins can read own profile"
+on public.admin_profiles
+for select
+to authenticated
+using (id = auth.uid());
+
+-- Owners can read all admin profiles.
+create policy "Owners can read admin profiles"
+on public.admin_profiles
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from public.admin_profiles
+    where id = auth.uid()
+      and role = 'owner'
+  )
+);
+
+-- Owners can manage admin profiles.
+create policy "Owners can manage admin profiles"
+on public.admin_profiles
+for all
+to authenticated
+using (
+  exists (
+    select 1
+    from public.admin_profiles
+    where id = auth.uid()
+      and role = 'owner'
+  )
+)
+with check (
+  exists (
+    select 1
+    from public.admin_profiles
+    where id = auth.uid()
+      and role = 'owner'
+  )
+);


### PR DESCRIPTION
## Summary
- Add Supabase Row Level Security policies.
- Allow public application submissions without exposing application data.
- Allow public reads only for published news.
- Restrict application and news management to admin profiles.
- Document the setup order and admin example using `admin@nois.dev`.

## Related issues
- Closes #22

## Notes
This PR only adds SQL and documentation. Frontend integration will be handled in a separate PR.