### PR TITLE
Set up GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,59 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.VITE_SUPABASE_PUBLISHABLE_KEY }}
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -121,4 +121,21 @@ refactor/short-description
 
 ## Deployment
 
-The app will be deployed with GitHub Pages once the production workflow is ready.
+The app is prepared to deploy with GitHub Pages through GitHub Actions.
+
+### GitHub Pages setup
+
+1. Open repository settings.
+2. Go to Pages.
+3. Set source to GitHub Actions.
+4. Add repository secrets:
+   - `VITE_SUPABASE_URL`
+   - `VITE_SUPABASE_PUBLISHABLE_KEY`
+5. Merge validated production changes into `main`.
+6. The deploy workflow will build the app and publish the `dist` folder.
+
+The Vite base path is configured for:
+
+```txt
+/NativasApp/
+```

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react-swc'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: '/NativasApp/',
   plugins: [react()]
 })


### PR DESCRIPTION
## Summary
- Configure Vite base path for `/NativasApp/`.
- Add GitHub Actions workflow to deploy `main` to GitHub Pages.
- Document GitHub Pages setup and required Supabase repository secrets.

## Related issues
- Closes #9

## Notes
After this PR is merged and production is promoted to `main`, GitHub Pages should be configured with source: GitHub Actions.