### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Build project
+        run: npm run build
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.VITE_SUPABASE_PUBLISHABLE_KEY }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ Run lint:
 npm run lint
 ```
 
+## Quality checks
+
+Pull requests to `develop` and `main` run a CI workflow with:
+
+- dependency installation
+- lint
+- production build
+
 ## Branch workflow
 
 - `main`: stable production branch.


### PR DESCRIPTION
## Summary
- Add CI workflow for pull requests targeting `develop` and `main`.
- Validate dependency installation, lint and production build.
- Document quality checks in README.

## Related issues
- Closes #30

## Notes
This workflow is separate from deployment. Deploy still runs from `main` only.