### PR TITLE
Replace legacy typed dependency

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-legacy-peer-deps=true

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.9.0",
-    "react-router-dom": "^6.13.0",
-    "react-typed": "^1.2.0"
+    "react-router-dom": "^6.13.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.28",

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,13 +1,24 @@
-import Typed from 'react-typed'
-import rollerImage from '../assets/roller.jpg'
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import rollerImage from '../assets/roller.jpg'
+
+const heroWords = ['Patina', 'Entrena', 'Únete']
 
 export function Hero () {
   const navigate = useNavigate()
+  const [wordIndex, setWordIndex] = useState(0)
 
   const handleUnetenos = () => {
-    navigate('/registrate')
+    navigate('/solicitud')
   }
+
+  useEffect(() => {
+    const intervalId = window.setInterval(() => {
+      setWordIndex((currentIndex) => (currentIndex + 1) % heroWords.length)
+    }, 1800)
+
+    return () => window.clearInterval(intervalId)
+  }, [])
 
   return (
     <div
@@ -16,27 +27,23 @@ export function Hero () {
     >
       <div className='max-w-[800px] w-full h-full text-center flex flex-col justify-center'>
         <p className='text-xl sm:text-2xl md:text-4xl md:mt-10 text-indigo-700 font-bold p-2'>
-          Patina con nosotros y gana dinero
+          Sé parte de Nativas Roller Derby
         </p>
         <h1 className='md:text-6xl sm:text-6xl text-4xl font-bold md-2'>Nativas</h1>
         <div className='flex justify-center items-center flex-col md:mt-10 '>
           <p className='md:text-5xl sm:text-4xl text-xl font-bold'>
             ¡Conviértete en parte de nuestra familia!
           </p>
-          <Typed
-            className='md:text-5xl sm:text-4xl text-indigo-700 text-xl font-bold pl-2'
-            strings={['Patina', 'Gana Premios', 'Diviértete']}
-            typeSpeed={120}
-            backSpeed={140}
-            loop
-          />
+          <span className='md:text-5xl sm:text-4xl text-indigo-700 text-xl font-bold pl-2 transition-opacity duration-500'>
+            {heroWords[wordIndex]}
+          </span>
         </div>
         <button
           onClick={handleUnetenos}
           type='button'
           className='bg-indigo-500 text-black w-[200px] rounded-md font-medium my-6 mx-auto py-3 transition-colors hover:bg-indigo-700 hover:border-white hover:border hover:text-white duration-3 '
         >
-          Unetenos
+          Únete
         </button>
         <div />
       </div>


### PR DESCRIPTION
## Summary
- Replace `react-typed` usage in the Hero with a small React state-based word rotation.
- Update the Hero CTA to point to `/solicitud`, which fits the recruitment flow better.
- Remove the legacy dependency from `package.json`.
- Remove the temporary `.npmrc` workaround.

## Related issues
- Closes #42

## Notes
`package-lock.json` may need to be regenerated locally with `npm install` before merging if CI reports a lockfile mismatch. The GitHub API output for the lockfile is too large to safely rewrite by hand here.