### PR TITLE
Add GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,34 @@
+---
+name: Bug
+description: Reportar un error o comportamiento inesperado
+title: "[Bug] "
+labels: ["bug"]
+---
+
+## Problema
+
+Describe el error de forma clara.
+
+## Pasos para reproducir
+
+1. 
+2. 
+3. 
+
+## Resultado actual
+
+Qué está pasando ahora.
+
+## Resultado esperado
+
+Qué debería pasar.
+
+## Evidencia
+
+Agrega capturas, videos, logs o links si aplica.
+
+## Criterios de aceptación
+
+- [ ] El error queda corregido.
+- [ ] Se validó el flujo afectado.
+- [ ] No se rompieron flujos relacionados.

--- a/.github/ISSUE_TEMPLATE/design.md
+++ b/.github/ISSUE_TEMPLATE/design.md
@@ -1,0 +1,33 @@
+---
+name: Diseño
+description: Crear o mejorar una sección visual del proyecto
+title: "[Design] "
+labels: ["design"]
+---
+
+## Objetivo visual
+
+Describe qué queremos mejorar o diseñar.
+
+## Referencias
+
+Agrega links, capturas o inspiración visual.
+
+## Alcance
+
+- [ ] Desktop
+- [ ] Mobile
+- [ ] Estados hover/focus
+- [ ] Estados loading/error/empty si aplica
+
+## Tareas
+
+- [ ] 
+- [ ] 
+- [ ] 
+
+## Criterios de aceptación
+
+- [ ] El diseño se ve consistente con NativasApp.
+- [ ] Funciona bien en mobile y desktop.
+- [ ] No depende de assets faltantes para verse ordenado.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,30 @@
+---
+name: Nueva funcionalidad
+description: Proponer una nueva funcionalidad para NativasApp
+title: "[Feature] "
+labels: ["feature"]
+---
+
+## Objetivo
+
+Describe qué queremos lograr.
+
+## Contexto
+
+Explica por qué esta funcionalidad aporta al proyecto.
+
+## Tareas
+
+- [ ] 
+- [ ] 
+- [ ] 
+
+## Criterios de aceptación
+
+- [ ] La funcionalidad cumple el objetivo.
+- [ ] La experiencia funciona en mobile y desktop.
+- [ ] No rompe flujos existentes.
+
+## Notas
+
+Agrega referencias, capturas o links si aplica.

--- a/.github/ISSUE_TEMPLATE/technical-debt.md
+++ b/.github/ISSUE_TEMPLATE/technical-debt.md
@@ -1,0 +1,30 @@
+---
+name: Deuda técnica
+description: Registrar limpieza, refactor o mejora interna
+title: "[Tech debt] "
+labels: ["technical-debt"]
+---
+
+## Problema
+
+Describe qué parte del código necesita limpieza o mejora.
+
+## Por qué importa
+
+Explica qué riesgo o fricción genera mantenerlo como está.
+
+## Propuesta
+
+Describe una solución simple.
+
+## Tareas
+
+- [ ] 
+- [ ] 
+- [ ] 
+
+## Criterios de aceptación
+
+- [ ] El código queda más simple o mantenible.
+- [ ] No cambia el comportamiento esperado.
+- [ ] Se validó lint/build si aplica.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## Summary
+
+Describe what this PR changes and why.
+
+## Changes
+
+- 
+- 
+- 
+
+## Screenshots
+
+Add screenshots or screen recordings for visual changes.
+
+## Checklist
+
+- [ ] I tested the change locally.
+- [ ] I ran lint/build when applicable.
+- [ ] I did not commit real environment values.
+- [ ] I updated documentation when needed.
+- [ ] The PR targets `develop`.
+
+## Related issues
+
+Closes #


### PR DESCRIPTION
## Summary
- Add pull request template with checklist.
- Add issue templates for features, bugs, design tasks and technical debt.
- Keep issue content in Spanish and PR structure in English.

## Related issues
- Closes #45

## Notes
This improves repository hygiene and keeps future work easier to review.