### PR TITLE
Fix GitHub Pages router basename

### DIFF
--- a/src/routers/router.jsx
+++ b/src/routers/router.jsx
@@ -9,9 +9,11 @@ import { RecoverPass } from '../containers/pages/RecoverPass.jsx'
 import { SolicitudPage } from '../containers/pages/SolicitudPage.jsx'
 import { ProtectorRuta } from './ProtectedRoute'
 
+const routerBaseName = import.meta.env.BASE_URL
+
 const AppRouter = () => {
   return (
-    <Router>
+    <Router basename={routerBaseName}>
       <Routes>
         <Route path='/' element={<Home />} />
         <Route path='/login' element={<Login />} />


### PR DESCRIPTION
## Summary
- Configure React Router with `import.meta.env.BASE_URL`.
- Fix GitHub Pages loading under `/NativasApp/` instead of falling into the 404 route.

## Notes
This should make the published GitHub Pages URL load the home page correctly.