### PR TITLE
Release GitHub Pages router fix

### DIFF
--- a/src/routers/router.jsx
+++ b/src/routers/router.jsx
@@ -9,9 +9,11 @@ import { RecoverPass } from '../containers/pages/RecoverPass.jsx'
 import { SolicitudPage } from '../containers/pages/SolicitudPage.jsx'
 import { ProtectorRuta } from './ProtectedRoute'
 
+const routerBaseName = import.meta.env.BASE_URL
+
 const AppRouter = () => {
   return (
-    <Router>
+    <Router basename={routerBaseName}>
       <Routes>
         <Route path='/' element={<Home />} />
         <Route path='/login' element={<Login />} />


### PR DESCRIPTION
## Summary
- Promote the router basename fix from `develop` to `main`.
- This should make the GitHub Pages URL load the home page correctly under `/NativasApp/`.

## Notes
Small production fix for the published preview.