### PR TITLE
Fix scroll and footer anchors

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom'
 import { FaInstagram } from 'react-icons/fa'
 
 const instagramUrl = 'https://www.instagram.com/nativas_rollerderby?igsh=MW84Mm5nbm5tN2ZvcA=='
@@ -15,10 +16,10 @@ export const Footer = () => {
 
         <div className='flex flex-col gap-4 md:items-end'>
           <nav className='flex flex-wrap gap-x-4 gap-y-2 text-sm font-semibold'>
-            <a href='/NativasApp/#about' className='transition hover:text-white'>Equipo</a>
-            <a href='/NativasApp/#training' className='transition hover:text-white'>Entrenamientos</a>
-            <a href='/NativasApp/#faq' className='transition hover:text-white'>FAQ</a>
-            <a href='/NativasApp/#apply' className='transition hover:text-white'>Postulación</a>
+            <Link to='/#about' className='transition hover:text-white'>Equipo</Link>
+            <Link to='/#training' className='transition hover:text-white'>Entrenamientos</Link>
+            <Link to='/#faq' className='transition hover:text-white'>FAQ</Link>
+            <Link to='/#apply' className='transition hover:text-white'>Postulación</Link>
           </nav>
 
           <a

--- a/src/routers/ScrollToTop.jsx
+++ b/src/routers/ScrollToTop.jsx
@@ -1,0 +1,24 @@
+import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+
+export function ScrollToTop () {
+  const { hash, pathname } = useLocation()
+
+  useEffect(() => {
+    if (hash) {
+      window.requestAnimationFrame(() => {
+        const target = document.querySelector(hash)
+
+        if (target) {
+          target.scrollIntoView({ behavior: 'smooth', block: 'start' })
+        }
+      })
+
+      return
+    }
+
+    window.scrollTo({ top: 0, left: 0, behavior: 'instant' })
+  }, [hash, pathname])
+
+  return null
+}

--- a/src/routers/router.jsx
+++ b/src/routers/router.jsx
@@ -8,12 +8,14 @@ import { UserPage } from '../containers/pages/UserPage.jsx'
 import { RecoverPass } from '../containers/pages/RecoverPass.jsx'
 import { SolicitudPage } from '../containers/pages/SolicitudPage.jsx'
 import { ProtectorRuta } from './ProtectedRoute'
+import { ScrollToTop } from './ScrollToTop'
 
 const routerBaseName = import.meta.env.BASE_URL
 
 const AppRouter = () => {
   return (
     <Router basename={routerBaseName}>
+      <ScrollToTop />
       <Routes>
         <Route path='/' element={<Home />} />
         <Route path='/login' element={<Login />} />


### PR DESCRIPTION
## Summary
- Add a route scroll handler.
- Start new route pages from the top.
- Scroll to hash sections when navigating from the form page.
- Use React Router links in the footer instead of hardcoded GitHub Pages paths.

## Notes
This should fix the application page opening at the bottom and make footer section links work from nested routes.