### PR TITLE
Release GitHub Pages hash router fix

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -16,10 +16,10 @@ export const Footer = () => {
 
         <div className='flex flex-col gap-4 md:items-end'>
           <nav className='flex flex-wrap gap-x-4 gap-y-2 text-sm font-semibold'>
-            <Link to='/#about' className='transition hover:text-white'>Equipo</Link>
-            <Link to='/#training' className='transition hover:text-white'>Entrenamientos</Link>
-            <Link to='/#faq' className='transition hover:text-white'>FAQ</Link>
-            <Link to='/#apply' className='transition hover:text-white'>Postulación</Link>
+            <Link to='/?section=about' className='transition hover:text-white'>Equipo</Link>
+            <Link to='/?section=training' className='transition hover:text-white'>Entrenamientos</Link>
+            <Link to='/?section=faq' className='transition hover:text-white'>FAQ</Link>
+            <Link to='/?section=apply' className='transition hover:text-white'>Postulación</Link>
           </nav>
 
           <a

--- a/src/routers/ScrollToTop.jsx
+++ b/src/routers/ScrollToTop.jsx
@@ -2,12 +2,15 @@ import { useEffect } from 'react'
 import { useLocation } from 'react-router-dom'
 
 export function ScrollToTop () {
-  const { hash, pathname } = useLocation()
+  const { pathname, search } = useLocation()
 
   useEffect(() => {
-    if (hash) {
+    const params = new URLSearchParams(search)
+    const section = params.get('section')
+
+    if (section) {
       window.requestAnimationFrame(() => {
-        const target = document.querySelector(hash)
+        const target = document.getElementById(section)
 
         if (target) {
           target.scrollIntoView({ behavior: 'smooth', block: 'start' })
@@ -18,7 +21,7 @@ export function ScrollToTop () {
     }
 
     window.scrollTo({ top: 0, left: 0, behavior: 'instant' })
-  }, [hash, pathname])
+  }, [pathname, search])
 
   return null
 }

--- a/src/routers/router.jsx
+++ b/src/routers/router.jsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Route, Routes } from 'react-router-dom'
+import { HashRouter as Router, Route, Routes } from 'react-router-dom'
 import { Error404 } from '../containers/errors/Error404'
 import { Home } from '../containers/pages/Home.jsx'
 import { Login } from '../containers/pages/Login.jsx'
@@ -10,11 +10,9 @@ import { SolicitudPage } from '../containers/pages/SolicitudPage.jsx'
 import { ProtectorRuta } from './ProtectedRoute'
 import { ScrollToTop } from './ScrollToTop'
 
-const routerBaseName = import.meta.env.BASE_URL
-
 const AppRouter = () => {
   return (
-    <Router basename={routerBaseName}>
+    <Router>
       <ScrollToTop />
       <Routes>
         <Route path='/' element={<Home />} />


### PR DESCRIPTION
## Summary
- Promote the HashRouter fix to `main`.
- Prevent GitHub Pages refreshes from breaking deep routes like the application form.
- Keep footer section navigation working with query-based scrolling.

## Notes
This should stabilize the public GitHub Pages preview for direct route access and reloads.