### PR TITLE
Add form endpoint env to deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,7 @@ jobs:
         env:
           VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
           VITE_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.VITE_SUPABASE_PUBLISHABLE_KEY }}
+          VITE_APPLICATION_FORM_ENDPOINT: ${{ secrets.VITE_APPLICATION_FORM_ENDPOINT }}
 
       - name: Setup Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
## Summary
- Pass `VITE_APPLICATION_FORM_ENDPOINT` to the GitHub Pages build.
- Prepare production deploys to use the configured form endpoint secret.

## Notes
The repository secret still needs to be created before real form submissions can work in production.