### PR TITLE
Release refresh scroll fix

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -16,10 +16,10 @@ export const Footer = () => {
 
         <div className='flex flex-col gap-4 md:items-end'>
           <nav className='flex flex-wrap gap-x-4 gap-y-2 text-sm font-semibold'>
-            <Link to='/?section=about' className='transition hover:text-white'>Equipo</Link>
-            <Link to='/?section=training' className='transition hover:text-white'>Entrenamientos</Link>
-            <Link to='/?section=faq' className='transition hover:text-white'>FAQ</Link>
-            <Link to='/?section=apply' className='transition hover:text-white'>Postulación</Link>
+            <Link to='/' state={{ section: 'about' }} className='transition hover:text-white'>Equipo</Link>
+            <Link to='/' state={{ section: 'training' }} className='transition hover:text-white'>Entrenamientos</Link>
+            <Link to='/' state={{ section: 'faq' }} className='transition hover:text-white'>FAQ</Link>
+            <Link to='/' state={{ section: 'apply' }} className='transition hover:text-white'>Postulación</Link>
           </nav>
 
           <a

--- a/src/routers/ScrollToTop.jsx
+++ b/src/routers/ScrollToTop.jsx
@@ -2,15 +2,18 @@ import { useEffect } from 'react'
 import { useLocation } from 'react-router-dom'
 
 export function ScrollToTop () {
-  const { pathname, search } = useLocation()
+  const { pathname, state } = useLocation()
 
   useEffect(() => {
-    const params = new URLSearchParams(search)
-    const section = params.get('section')
+    if ('scrollRestoration' in window.history) {
+      window.history.scrollRestoration = 'manual'
+    }
+  }, [])
 
-    if (section) {
+  useEffect(() => {
+    if (state?.section) {
       window.requestAnimationFrame(() => {
-        const target = document.getElementById(section)
+        const target = document.getElementById(state.section)
 
         if (target) {
           target.scrollIntoView({ behavior: 'smooth', block: 'start' })
@@ -21,7 +24,7 @@ export function ScrollToTop () {
     }
 
     window.scrollTo({ top: 0, left: 0, behavior: 'instant' })
-  }, [pathname, search])
+  }, [pathname, state])
 
   return null
 }


### PR DESCRIPTION
## Summary
- Promote the refresh scroll fix to `main`.
- Stop persistent section navigation from reopening the page at training or FAQ after refresh.
- Keep footer section links working through React Router state.

## Notes
Small UX release for the public GitHub Pages preview.